### PR TITLE
Improve accounts API

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Examples of calls can be found in the `examples/` directory. Clone this reposito
 cargo run --example get-trades
 ```
 
-Example with `get_trades()`:
+Example with `list_trades()`:
 
 ```rust
 use luno::{LunoClient, TradingPair};
@@ -40,7 +40,7 @@ async fn main() {
 
     let client = LunoClient::new(key, secret);
 
-    match client.get_trades(TradingPair::XBTZAR).await {
+    match client.list_trades(TradingPair::XBTZAR).await {
         Err(e) => eprintln!("{:?}", e),
         Ok(result) => {
             if let Some(trade) = result.trades {

--- a/examples/get-balances.rs
+++ b/examples/get-balances.rs
@@ -7,7 +7,7 @@ async fn main() {
 
     let client = LunoClient::new(key, secret);
 
-    match client.get_balances().await {
+    match client.list_balances().await {
         Err(e) => eprintln!("{:?}", e),
         Ok(result) => {
             if let Some(balance) = result.balance {

--- a/examples/get-pending-transactions.rs
+++ b/examples/get-pending-transactions.rs
@@ -7,7 +7,7 @@ async fn main() {
 
     let client = LunoClient::new(key, secret);
 
-    match client.get_pending_transactions("ACCOUNT_ID").await {
+    match client.list_pending_transactions("ACCOUNT_ID").await {
         Err(e) => eprintln!("{:?}", e),
         Ok(result) => {
             if let Some(txn) = result.pending {

--- a/examples/get-tickers.rs
+++ b/examples/get-tickers.rs
@@ -7,7 +7,7 @@ async fn main() {
 
     let client = LunoClient::new(key, secret);
 
-    match client.get_tickers().await {
+    match client.list_tickers().await {
         Err(e) => eprintln!("{:?}", e),
         Ok(result) => {
             if let Some(ticker) = result.tickers {

--- a/examples/get-trades.rs
+++ b/examples/get-trades.rs
@@ -7,7 +7,7 @@ async fn main() {
 
     let client = LunoClient::new(key, secret);
 
-    match client.get_trades(TradingPair::XBTZAR).await {
+    match client.list_trades(TradingPair::XBTZAR).await {
         Err(e) => eprintln!("{:?}", e),
         Ok(result) => {
             if let Some(trade) = result.trades {

--- a/examples/get-transactions.rs
+++ b/examples/get-transactions.rs
@@ -7,7 +7,7 @@ async fn main() {
 
     let client = LunoClient::new(key, secret);
 
-    match client.get_transactions("ACCOUNT_ID", 1, 100).await {
+    match client.list_transactions("ACCOUNT_ID", 1, 100).await {
         Err(e) => eprintln!("{:?}", e),
         Ok(result) => {
             if let Some(txn) = result.transactions {

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use futures::Future;
 use serde::{Deserialize, Serialize};
 

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -1,4 +1,9 @@
+use std::collections::HashMap;
+
+use futures::Future;
 use serde::{Deserialize, Serialize};
+
+use crate::client;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Account {
@@ -20,4 +25,30 @@ pub struct Balance {
 #[derive(Debug, Deserialize)]
 pub struct BalanceList {
     pub balance: Option<Vec<Balance>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateAccountNameResponse {
+    pub success: bool,
+}
+pub struct ListBalancesBuilder<'a> {
+    pub(crate) luno_client: &'a client::LunoClient,
+    pub(crate) url: reqwest::Url,
+    pub(crate) assets: Option<&'a [&'a str]>,
+}
+
+impl<'a> ListBalancesBuilder<'a> {
+    pub fn with_assets(&mut self, assets: &'a [&'a str]) -> &mut ListBalancesBuilder<'a> {
+        self.assets = Some(assets);
+        self
+    }
+
+    pub fn list(&self) -> impl Future<Output = Result<BalanceList, reqwest::Error>> + '_ {
+        let mut url = self.url.clone();
+        if let Some(assets) = self.assets {
+            url.query_pairs_mut()
+                .append_pair("assets", &assets.join(","));
+        }
+        self.luno_client.get(url)
+    }
 }

--- a/src/trades.rs
+++ b/src/trades.rs
@@ -45,13 +45,13 @@ impl<'a> ListTradesBuilder<'a> {
 
     pub fn get(&self) -> impl Future<Output = Result<TradeList, reqwest::Error>> + '_ {
         let mut url = self.url.clone();
-        if self.since.is_some() {
+        if let Some(since) = self.since {
             url.query_pairs_mut()
-                .append_pair("since", &self.since.unwrap().to_string());
+                .append_pair("since", &since.to_string());
         }
-        if self.limit.is_some() {
+        if let Some(limit) = self.limit {
             url.query_pairs_mut()
-                .append_pair("limit", &self.limit.unwrap().to_string());
+                .append_pair("limit", &limit.to_string());
         }
         self.luno_client.get(url)
     }

--- a/src/urls.rs
+++ b/src/urls.rs
@@ -52,13 +52,21 @@ impl UrlMaker {
         self.build_url("accounts")
     }
 
+    // Build https://api.mybitx.com/api/1/accounts/{id}/{name}
+    pub fn account_name(&self, account_id: &str, name: &str) -> reqwest::Url {
+        let mut url = self.accounts();
+        url.path_segments_mut().unwrap().extend(&[account_id]);
+        url.query_pairs_mut().append_pair("name", name);
+        url
+    }
+
     // Build https://api.mybitx.com/api/1/balance
     pub fn balance(&self) -> reqwest::Url {
         self.build_url("balance")
     }
 
-    // Build https://api.mybitx.com/api/1/account/:id/transactions
-    pub fn transactions(&self, account_id: &str, min_row: u64, max_row: u64) -> reqwest::Url {
+    // Build https://api.mybitx.com/api/1/account/{id}/transactions
+    pub fn transactions(&self, account_id: &str, min_row: i64, max_row: i64) -> reqwest::Url {
         let mut url = self.accounts();
         url.path_segments_mut()
             .unwrap()
@@ -69,7 +77,7 @@ impl UrlMaker {
         url
     }
 
-    // Build https://api.mybitx.com/api/1/account/:id/pending
+    // Build https://api.mybitx.com/api/1/account/{id}/pending
     pub fn pending_transactions(&self, account_id: &str) -> reqwest::Url {
         let mut url = self.accounts();
         url.path_segments_mut()
@@ -98,7 +106,7 @@ impl UrlMaker {
         self.build_url("stoporder")
     }
 
-    // Build https://api.mybitx.com/api/1/orders/:id
+    // Build https://api.mybitx.com/api/1/orders/{id}
     pub fn orders(&self, order_id: &str) -> reqwest::Url {
         let mut url = self.build_url("orders");
         url.path_segments_mut().unwrap().extend(&[order_id]);


### PR DESCRIPTION
Adds the `update_account_name` call to update an asset account given an `account_id` and new `name`.
Some general clean up and renaming to better align intent of calls. Refactor some cases to more
idiomatic Rust.